### PR TITLE
renamed key from req_sessionID to req_session_id

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = {
 					req_user_id: (req.user) ? req.user.id : null,
 					req_user_username: (req.user) ? req.user.username : null,
 					req_user_details: (req.user) ? req.user : null,
-					req_sessionID: req.sessionID,
+					req_session_id: req.sessionID,
 				};
 
 				// remove sensitive information


### PR DESCRIPTION
As we are pushing these server logs into redshift, but redshift only allows to create columns in lowercase. So, we need to change the server log's key from _req_sessionID_ to _req_session_id_.

Because of this redshift is not able to populate session_id of the request/response. 